### PR TITLE
Update API-Blueprint-Documentation.md

### DIFF
--- a/API-Blueprint-Documentation.md
+++ b/API-Blueprint-Documentation.md
@@ -300,7 +300,7 @@ You can also define the parameters `type` and whether or not it's `required`.
 ```php
 /**
  * @Parameters({
- *      @Parameter("example", type="integer", required=true description="This is an example.", default=1)
+ *      @Parameter("example", type="integer", required=true, description="This is an example.", default=1)
  * })
  */
 public function index()


### PR DESCRIPTION
required=true 后缺少逗号。

`
[Syntax Error] Expected Doctrine\Common\Annotation
  s\DocLexer::T_CLOSE_PARENTHESIS, got 'description'
   at position xxx
`